### PR TITLE
Add cheat options for campaign AIs

### DIFF
--- a/Changelod.md
+++ b/Changelod.md
@@ -1,7 +1,12 @@
 Changelog
 
+# v6 (09.07.2023)
+- Added economy, and build power cheat options for AIs, they are applied to all AI armies, including allied ones.
+- Cleaned up the most commonly used *save.lua* files found in the lua/AI/OpAI folder, they contained a lot of duplicate data that weren't even used.
+
 # v5 (04.07.2023)
 - Fixed the BaseManager messing up ACU upgrades, for real this time
+- Fixed the BaseManager not considering its Engineers as dead if they were either reclaimed or captured.
 - AttackManager and PBM now cache their formed platoons' origin base.
 - With that, AIs should now only use transports to pick up land platoons units if their origin bases match.
 - Added the option to create unique transport platoons, and land platoons to pick unique transport platoons as well, just specify the 'BaseName' in PlatoonData

--- a/hook/lua/AI/OpAI/AirAttacks_save.lua
+++ b/hook/lua/AI/OpAI/AirAttacks_save.lua
@@ -1,4 +1,3 @@
-
 --[[                                                                           ]]--
 --[[  Automatically generated code (do not edit)                               ]]--
 --[[                                                                           ]]--
@@ -364,19 +363,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -393,19 +383,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -425,23 +406,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -458,23 +427,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -491,23 +448,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -524,23 +469,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -561,23 +494,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -594,23 +515,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -632,23 +541,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -665,23 +562,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -698,23 +583,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -731,23 +604,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -764,27 +625,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 0 },
-                                {'default_brain','1','0'}
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+							[3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 , 0 } },
+                            --[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -802,27 +648,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 0 },
-                                {'default_brain','1','0'}
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 , 0 } },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -840,23 +671,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -873,23 +692,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -911,23 +718,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -945,23 +740,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -979,23 +762,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                             [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
                                 {'default_brain', 1, 2, 3 },
                                 {'default_brain','1', '2', '3'}
@@ -1029,27 +800,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 2 , 3 },
-                                {'default_brain', '1', '2','3' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1066,27 +822,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 2 , 3 },
-                                {'default_brain', '1', '2','3' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1103,27 +844,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 2, 3 },
-                                {'default_brain', '1', '2', '3' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} }, 
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3 } },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1140,27 +866,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 1 },
-                                {'default_brain','default_builder_name','1'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 2, 3 },
-                                {'default_brain', '1', '2','3' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain', 'default_builder_name', 1 } },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1181,27 +892,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain',4, 0 },
-                                {'default_brain', '4','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1218,27 +914,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 4, 0 },
-                                {'default_brain', '4','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1255,27 +936,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 4, 0 },
-                                {'default_brain', '4','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1295,27 +961,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 0 },
-                                {'default_brain', '1','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1332,27 +983,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 0 },
-                                {'default_brain', '1','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1369,27 +1005,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 0 },
-                                {'default_brain', '1','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1411,27 +1032,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0 },
-                                {'default_brain', '2','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1448,27 +1054,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0 },
-                                {'default_brain', '2','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1485,27 +1076,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0 },
-                                {'default_brain', '2','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1522,27 +1098,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0 },
-                                {'default_brain', '2','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1560,27 +1121,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0 },
-                                {'default_brain', '2','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1597,27 +1143,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0 },
-                                {'default_brain', '2','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+							--[[[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },]]
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1637,23 +1168,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1670,23 +1189,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1703,23 +1210,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1736,23 +1231,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1771,27 +1254,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
+							--[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1808,27 +1276,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
+							--[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1845,27 +1298,12 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            --[[[2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
-                                {'default_brain','default_builder_name', 2 },
-                                {'default_brain','default_builder_name','2'}
-                            },]]
-                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0 },
-                                {'default_brain', '3','0' }
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
+							--[3] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter', {'default_brain','default_builder_name', 2} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1888,32 +1326,16 @@ Scenario = {
                         BuildTimeOut = 500,
                         PlatoonType = 'Air',
                         RequiresConstruction = false,
-						--UsePool = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackMasterCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackMasterCountDifficulty', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
                         },
                         PlatoonBuildCallbacks = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon',
-                                {'default_brain','default_platoon'},
-                                {'default_brain','default_platoon'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon', {'default_brain','default_platoon'} },
                         },
                         PlatoonAddFunctions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon',
-                                {'default_platoon'},
-                                {'default_platoon'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon', {'default_platoon'} },
                         },
                         PlatoonData = {
                             {type = 3, name = 'AMMasterPlatoon',  value = true},

--- a/hook/lua/AI/OpAI/BaseManager.lua
+++ b/hook/lua/AI/OpAI/BaseManager.lua
@@ -120,7 +120,7 @@ BaseManager = Class(BaseManagerTemplate) {
         end
 		
 		-- A brief explanation on what was messed up with this previously that messed up enhancements with prerequisites
-			-- The first check is was what caused issues previously, it checks if there's already an upgrade on the slot our wanted enhancement wants to occupy	
+			-- The first check is what caused issues previously, it checks if there's already an upgrade on the slot our wanted enhancement wants to occupy	
 			-- "SimUnitEnhancements" is a global table that's created in "lua/SimSync.lua", and stores unit enhancements using the following data structure:
 			-- SimUnitEnhancements[unit.EntityId], an example of this:
 			--------------------------------

--- a/hook/lua/AI/OpAI/BasicLandAttack_save.lua
+++ b/hook/lua/AI/OpAI/BasicLandAttack_save.lua
@@ -411,19 +411,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -439,23 +430,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -471,23 +450,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -503,23 +470,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -535,23 +490,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -567,23 +510,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -599,19 +530,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -627,23 +549,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -659,23 +569,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -696,19 +594,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -724,23 +613,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -756,23 +633,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -788,23 +653,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -820,23 +673,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -852,19 +693,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -880,19 +712,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -908,19 +731,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -936,19 +750,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -964,23 +769,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -996,23 +789,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1028,23 +809,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1060,23 +829,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1098,23 +855,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1130,23 +875,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1162,19 +895,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1190,19 +914,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1218,19 +933,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1254,19 +960,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1282,19 +979,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1310,19 +998,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1338,19 +1017,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1366,23 +1036,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4 },
-                                {'default_brain','1','2','4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1398,23 +1056,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3 , 0 },
-                                {'default_brain','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1435,19 +1081,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1463,19 +1100,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1491,19 +1119,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1521,23 +1140,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 0},
-                                {'default_brain','2','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1556,19 +1163,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1584,19 +1182,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1612,19 +1201,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1640,23 +1220,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4},
-                                {'default_brain', '1', '2', '4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 , 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1672,23 +1240,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 , 2, 4},
-                                {'default_brain', '1', '2', '4'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 , 2, 4} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1704,23 +1260,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 4, 0},
-                                {'default_brain','2','4','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 4, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1736,23 +1280,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 4, 0},
-                                {'default_brain','2','4','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 4, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1768,23 +1300,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 2, 4, 0},
-                                {'default_brain','2','4','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 4, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1800,23 +1320,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 3, 0},
-                                {'default_brain','1','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1832,23 +1340,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 3, 0},
-                                {'default_brain','1','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1864,23 +1360,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 3, 0},
-                                {'default_brain','1','3','0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1897,23 +1381,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0},
-                                {'default_brain', '3', '0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1929,23 +1401,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0},
-                                {'default_brain', '3', '0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1961,23 +1421,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 3, 0},
-                                {'default_brain', '3', '0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -1995,23 +1443,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 0 },
-                                {'default_brain', '1', '0'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0 } },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -2027,23 +1463,11 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 0},
-                                {'default_brain', '1', '0'},
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty', {'default_brain', 'default_master'} },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
                         },
                         PlatoonData = {
                             {type = 5, name = 'AMPlatoons', value = {
@@ -2060,19 +1484,10 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/BasicLandAttack_editorfunctions.lua', 'NeedTransports',
-                                {'default_brain','default_master','default_location_type'},
-                                {'default_brain','default_master','default_location_type'}
-                            },
-                            [1] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 0 },
-                                {'default_brain','1', '0'}
-                            },
+                            [0] = {'/lua/ai/opai/BasicLandAttack_editorfunctions.lua', 'NeedTransports', {'default_brain','default_master', 'default_location_type'} },
+                            [1] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0 } },
                         },
                         PlatoonData = {
                         },
@@ -2085,15 +1500,9 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/BasicLandAttack_editorfunctions.lua', 'NeedTransports',
-                                {'default_brain','default_master','default_location_type'},
-                                {'default_brain','default_master','default_location_type'}
-                            },
+                            [0] = {'/lua/ai/opai/BasicLandAttack_editorfunctions.lua', 'NeedTransports', {'default_brain','default_master', 'default_location_type'} },
                         },
                         PlatoonData = {
                         },
@@ -2106,15 +1515,9 @@ Scenario = {
                         LocationType = 'MAIN',
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/ai/opai/BasicLandAttack_editorfunctions.lua', 'NeedTransports',
-                                {'default_brain','default_master','default_location_type'},
-                                {'default_brain','default_master','default_location_type'}
-                            },
+                            [0] = {'/lua/ai/opai/BasicLandAttack_editorfunctions.lua', 'NeedTransports', {'default_brain','default_master', 'default_location_type'} },
                         },
                         PlatoonData = {
                         },
@@ -2135,32 +1538,16 @@ Scenario = {
                         BuildTimeOut = 240,
                         PlatoonType = 'Land',
                         RequiresConstruction = false,
-						--UsePool = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat', {'default_platoon'} },
                         BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackMasterCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain', 'default_master'} },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackMasterCountDifficulty', {'default_brain', 'default_master'} },
                         },
                         PlatoonBuildCallbacks = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon',
-                                {'default_brain','default_platoon'},
-                                {'default_brain','default_platoon'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon', {'default_brain','default_platoon'} },
                         },
                         PlatoonAddFunctions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon',
-                                {'default_platoon'},
-                                {'default_platoon'}
-                            },
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon', {'default_platoon'} },
                         },
                         PlatoonData = {
                             {type = 3, name = 'AMMasterPlatoon',  value = true},

--- a/hook/lua/AI/OpAI/EngineerAttack_save.lua
+++ b/hook/lua/AI/OpAI/EngineerAttack_save.lua
@@ -97,26 +97,12 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports', {'default_brain','default_master','default_location_type'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 } },
                         },
-                        BuildConditions =
-                        {
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports',
-                                {'default_brain','default_master','default_location_type'},
-                                {'default_brain','default_master','default_location_type'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 },
-                                {'default_brain','1'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                         },
                         ChildrenType = {'T3Transports'},
                     },
@@ -129,26 +115,12 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports', {'default_brain','default_master','default_location_type'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3 } },
                         },
-                        BuildConditions =
-                        {
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports',
-                                {'default_brain','default_master','default_location_type'},
-                                {'default_brain','default_master','default_location_type'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 2, 3 },
-                                {'default_brain', '1', '2', '3'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                         },
                         ChildrenType = {'T2Transports'},
                     },
@@ -161,26 +133,12 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports', {'default_brain','default_master','default_location_type'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4 } },
                         },
-                        BuildConditions =
-                        {
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports',
-                                {'default_brain','default_master','default_location_type'},
-                                {'default_brain','default_master','default_location_type'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 4 },
-                                {'default_brain','4'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                         },
                         ChildrenType = {'T2Transports'},
                     },
@@ -193,12 +151,7 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Air',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'TransportPool',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'TransportPool', {'default_platoon'} },
                         BuildConditions =
                         {
                             {'/lua/ai/opai/EngineerAttack_save.lua', 'NeedEngineerTransports',
@@ -206,8 +159,7 @@ Scenario = {
                                 {'default_brain','default_master','default_location_type'}
                             },
                         },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                         },
                         ChildrenType = {'T1Transports'},
                     },
@@ -223,30 +175,13 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 } },
                         },
-                        BuildConditions =
-                        {
-                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 },
-                                {'default_brain','1'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {
                                 type = 5,
                                 name = 'AMPlatoons',
@@ -271,31 +206,13 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3 } },
                         },
-                        BuildConditions =
-                        {
-                            {
-                                '/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1, 2, 3 },
-                                {'default_brain', '1', '2', '3'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {
                                 type = 5,
                                 name = 'AMPlatoons',
@@ -320,31 +237,13 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1 } },
                         },
-                        BuildConditions =
-                        {
-                            {
-                                '/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 1 },
-                                {'default_brain', '1'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {
                                 type = 5,
                                 name = 'AMPlatoons',
@@ -369,31 +268,13 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4 } },
                         },
-                        BuildConditions =
-                        {
-                            {
-                                '/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 4 },
-                                {'default_brain','4'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {
                                 type = 5,
                                 name = 'AMPlatoons',
@@ -418,26 +299,12 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount', {'default_brain','default_master'} },
                         },
-                        BuildConditions =
-                        {
-                            {
-                                '/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {
                                 type = 5,
                                 name = 'AMPlatoons',
@@ -462,31 +329,13 @@ Scenario = {
                         BuildTimeOut = -1,
                         PlatoonType = 'Land',
                         RequiresConstruction = true,
-                        PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4 } },
                         },
-                        BuildConditions =
-                        {
-                            {
-                                '/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackChildCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {
-                                '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 4 },
-                                {'default_brain','4'}
-                            },
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {
                                 type = 5,
                                 name = 'AMPlatoons',
@@ -515,37 +364,18 @@ Scenario = {
                         PlatoonType = 'Any',
                         RequiresConstruction = true,
                         PlatoonAIFunction =
-                        {
-                            '/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat',
-                            {'default_platoon'},
-                            {'default_platoon'}
+                        {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackMasterCount', {'default_brain','default_master'} },
                         },
-                        BuildConditions =
-                        {
-                            {
-                                '/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            {'/lua/ai/opai/EngineerAttack_save.lua', 'EngineerAttackMasterCount',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
+                        PlatoonBuildCallbacks = {
+							{'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon', {'default_brain','default_platoon'} }, 
+						},
+                        PlatoonAddFunctions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon', {'default_platoon'} },
                         },
-                        PlatoonBuildCallbacks =
-                        {
-                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon',
-                            {'default_brain','default_platoon'},
-                            {'default_brain','default_platoon'}},
-                        },
-                        PlatoonAddFunctions =
-                        {
-                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon',
-                            {'default_platoon'},
-                            {'default_platoon'}},
-                        },
-                        PlatoonData =
-                        {
+                        PlatoonData = {
                             {type = 3, name = 'AMMasterPlatoon',  value = true},
                             {type = 3, name = 'UsePool', value = false},
                         },

--- a/hook/lua/AI/OpAI/NavalAttacks_save.lua
+++ b/hook/lua/AI/OpAI/NavalAttacks_save.lua
@@ -1,0 +1,1866 @@
+--[[                                                                           ]]--
+--[[  Automatically generated code (do not edit)                               ]]--
+--[[                                                                           ]]--
+--[[                                                                           ]]--
+--[[  Scenario                                                                 ]]--
+--[[                                                                           ]]--
+Scenario = {
+    next_area_id = '1',
+    --[[                                                                           ]]--
+    --[[  Props                                                                    ]]--
+    --[[                                                                           ]]--
+    Props = {
+    },
+    --[[                                                                           ]]--
+    --[[  Areas                                                                    ]]--
+    --[[                                                                           ]]--
+    Areas = {
+    },
+    --[[                                                                           ]]--
+    --[[  Markers                                                                  ]]--
+    --[[                                                                           ]]--
+    MasterChain = {
+        ['_MASTERCHAIN_'] = {
+            Markers = {
+            },
+        },
+    },
+    Chains = {
+    },
+    --[[                                                                           ]]--
+    --[[  Orders                                                                   ]]--
+    --[[                                                                           ]]--
+    next_queue_id = '1',
+    Orders = {
+    },
+    --[[                                                                           ]]--
+    --[[  Platoons                                                                 ]]--
+    --[[                                                                           ]]--
+    next_platoon_id = '14',
+    Platoons =
+    {
+        ['OST_BLANK_TEMPLATE'] = {
+            'OST_BLANK_TEMPLATE',
+            '',
+        },
+        -- Common
+        ['OST_NavalAttacks_FrigatePlatoon'] = {
+            'OST_NavalAttacks_FrigatePlatoon',
+            '',
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T1SubmarinePlatoon'] = {
+            'OST_NavalAttacks_T1SubmarinePlatoon',
+            '',
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T1Platoon1'] = {
+            'OST_NavalAttacks_T1Platoon1',
+            '',
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_DestroyerPlatoon'] = {
+            'OST_NavalAttacks_DestroyerPlatoon',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+        ['OST_NavalAttacks_CruiserPlatoon'] = {
+            'OST_NavalAttacks_CruiserPlatoon',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+        ['OST_NavalAttacks_T2Platoon1'] = {
+            'OST_NavalAttacks_T2Platoon1',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+        ['OST_NavalAttacks_T2Platoon2'] = {
+            'OST_NavalAttacks_T2Platoon2',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon3'] = {
+            'OST_NavalAttacks_T2Platoon3',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon4'] = {
+            'OST_NavalAttacks_T2Platoon4',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T2Platoon5'] = {
+            'OST_NavalAttacks_T2Platoon5',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon6'] = {
+            'OST_NavalAttacks_T2Platoon6',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon7'] = {
+            'OST_NavalAttacks_T2Platoon7',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T2Platoon8'] = {
+            'OST_NavalAttacks_T2Platoon8',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_BattleshipPlatoon'] = {
+            'OST_NavalAttacks_BattleshipPlatoon',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+        },
+        ['OST_NavalAttacks_T3Platoon1'] = {
+            'OST_NavalAttacks_T3Platoon1',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+        ['OST_NavalAttacks_T3Platoon2'] = {
+            'OST_NavalAttacks_T3Platoon2',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+        ['OST_NavalAttacks_T3Platoon3'] = {
+            'OST_NavalAttacks_T3Platoon3',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+        ['OST_NavalAttacks_T3Platoon4'] = {
+            'OST_NavalAttacks_T3Platoon4',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T3Platoon5'] = {
+            'OST_NavalAttacks_T3Platoon5',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T3Platoon6'] = {
+            'OST_NavalAttacks_T3Platoon6',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T3Platoon7'] = {
+            'OST_NavalAttacks_T3Platoon7',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T3Platoon8'] = {
+            'OST_NavalAttacks_T3Platoon8',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T3Platoon9'] = {
+            'OST_NavalAttacks_T3Platoon9',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T3Platoon10'] = {
+            'OST_NavalAttacks_T3Platoon10',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T3Platoon11'] = {
+            'OST_NavalAttacks_T3Platoon11',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T3Platoon12'] = {
+            'OST_NavalAttacks_T3Platoon12',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+
+
+
+        -- Mixed
+        ['OST_NavalAttacks_T2SubmarinePlatoon1'] = {
+            'OST_NavalAttacks_T2SubmarinePlatoon1',
+            '',
+            { 'xes0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2SubmarinePlatoon2'] = {
+            'OST_NavalAttacks_T2SubmarinePlatoon2',
+            '',
+            { 'xes0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_UtilityPlatoon'] = {
+            'OST_NavalAttacks_UtilityPlatoon',
+            '',
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_CarrierPlatoon'] = {
+            'OST_NavalAttacks_CarrierPlatoon',
+            '',
+            { 'ues0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+        },
+        ['OST_NavalAttacks_NukeSubmarinePlatoon'] = {
+            'OST_NavalAttacks_NukeSubmarinePlatoon',
+            '',
+            { 'ues0304', -1, 1, 'attack', 'AttackFormation' }, -- NukeSubmarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon1'] = {
+            'OST_NavalAttacks_T2MixedPlatoon1',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'xes0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon2'] = {
+            'OST_NavalAttacks_T2MixedPlatoon2',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon3'] = {
+            'OST_NavalAttacks_T2MixedPlatoon3',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon4'] = {
+            'OST_NavalAttacks_T2MixedPlatoon4',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon5'] = {
+            'OST_NavalAttacks_T2MixedPlatoon5',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon6'] = {
+            'OST_NavalAttacks_T2MixedPlatoon6',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T3MixedPlatoon1'] = {
+            'OST_NavalAttacks_T3MixedPlatoon1',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+        },
+        ['OST_NavalAttacks_T3MixedPlatoon2'] = {
+            'OST_NavalAttacks_T3MixedPlatoon2',
+            '',
+            { 'ues0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+
+
+
+        -- Aeon Specific
+        ['OST_NavalAttacks_AABoatPlatoon'] = {
+            'OST_NavalAttacks_AABoatPlatoon',
+            '',
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_T1AeonPlatoon1'] = {
+            'OST_NavalAttacks_T1AeonPlatoon1',
+            '',
+            { 'uas0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_T1AeonPlatoon2'] = {
+            'OST_NavalAttacks_T1AeonPlatoon2',
+            '',
+            { 'uas0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_T1AeonPlatoon3'] = {
+            'OST_NavalAttacks_T1AeonPlatoon3',
+            '',
+            { 'uas0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'uas0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_MissileShipPlatoon'] = {
+            'OST_NavalAttacks_MissileShipPlatoon',
+            '',
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+        },
+        ['OST_NavalAttacks_AAPlatoon'] = {
+            'OST_NavalAttacks_AAPlatoon',
+            '',
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_T2AeonPlatoon1'] = {
+            'OST_NavalAttacks_T2AeonPlatoon1',
+            '',
+            { 'uas0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'uas0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_T3AeonPlatoon1'] = {
+            'OST_NavalAttacks_T3AeonPlatoon1',
+            '',
+            { 'uas0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+        },
+        ['OST_NavalAttacks_T3AeonPlatoon2'] = {
+            'OST_NavalAttacks_T3AeonPlatoon2',
+            '',
+            { 'uas0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+        },
+        ['OST_NavalAttacks_T3AeonPlatoon3'] = {
+            'OST_NavalAttacks_T3AeonPlatoon3',
+            '',
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+
+
+
+        -- Cybran Specific
+        ['OST_NavalAttacks_T2CybranPlatoon1'] = {
+            'OST_NavalAttacks_T2CybranPlatoon1',
+            '',
+            { 'urs0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'urs0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xrs0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+            { 'xrs0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+
+
+
+        -- Seraphim Specific
+        ['OST_NavalAttacks_T3SubmarinePlatoon'] = {
+            'OST_NavalAttacks_T3SubmarinePlatoon',
+            '',
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+        },
+        ['OST_NavalAttacks_T3SeraphimPlatoon1'] = {
+            'OST_NavalAttacks_T3SeraphimPlatoon1',
+            '',
+            { 'xss0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+        },
+        ['OST_NavalAttacks_T3SeraphimPlatoon2'] = {
+            'OST_NavalAttacks_T3SeraphimPlatoon2',
+            '',
+            { 'xss0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+        },
+        ['OST_NavalAttacks_T3SeraphimPlatoon3'] = {
+            'OST_NavalAttacks_T3SeraphimPlatoon3',
+            '',
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+            { 'xss0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+
+
+
+        -- UEF Specific
+        ['OST_NavalAttacks_TropBoatPlatoon'] = {
+            'OST_NavalAttacks_TropBoatPlatoon',
+            '',
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon1'] = {
+            'OST_NavalAttacks_T2UEFPlatoon1',
+            '',
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon2'] = {
+            'OST_NavalAttacks_T2UEFPlatoon2',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon3'] = {
+            'OST_NavalAttacks_T2UEFPlatoon3',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon4'] = {
+            'OST_NavalAttacks_T2UEFPlatoon4',
+            '',
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon5'] = {
+            'OST_NavalAttacks_T2UEFPlatoon5',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon6'] = {
+            'OST_NavalAttacks_T2UEFPlatoon6',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon7'] = {
+            'OST_NavalAttacks_T2UEFPlatoon7',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+        },
+        ['OST_NavalAttacks_T2UEFPlatoon8'] = {
+            'OST_NavalAttacks_T2UEFPlatoon8',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0102', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_BattleCruiserPlatoon'] = {
+            'OST_NavalAttacks_BattleCruiserPlatoon',
+            '',
+            { 'xes0307', -1, 1, 'attack', 'AttackFormation' }, -- BattleCruisers
+        },
+        ['OST_NavalAttacks_T3UEFPlatoon1'] = {
+            'OST_NavalAttacks_T3UEFPlatoon1',
+            '',
+            { 'xes0307', -1, 1, 'attack', 'AttackFormation' }, -- BattleCruisers
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+        },
+        ['OST_NavalAttacks_T3UEFPlatoon2'] = {
+            'OST_NavalAttacks_T3UEFPlatoon2',
+            '',
+            { 'xes0307', -1, 1, 'attack', 'AttackFormation' }, -- BattleCruisers
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+    },
+    --[[                                                                           ]]--
+    --[[  Armies                                                                   ]]--
+    --[[                                                                           ]]--
+    next_army_id = '2',
+    next_group_id = '1',
+    next_unit_id = '1',
+    Armies =
+    {
+        --[[                                                                           ]]--
+        --[[  Army                                                                     ]]--
+        --[[                                                                           ]]--
+        ['ARMY_1'] =
+        {
+            personality = '',
+            plans = '',
+            color = 0,
+            faction = 0,
+            Economy = {
+                mass = 0,
+                energy = 0,
+            },
+            Alliances = {
+            },
+            ['Units'] = GROUP {
+                orders = '',
+                platoon = '',
+                Units = {
+                    ['INITIAL'] = GROUP {
+                        orders = '',
+                        platoon = '',
+                        Units = {
+                        },
+                    },
+                },
+            },
+            PlatoonBuilders = {
+                next_platoon_builder_id = '14',
+                Builders = {
+                    -- Common
+                    ['OSB_Child_NavalAttacks_FrigatePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_FrigatePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1SubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1SubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1Platoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1Platoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_DestroyerPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_DestroyerPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers'},
+                    },
+                    ['OSB_Child_NavalAttacks_CruiserPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_CruiserPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon5'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon5',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon6'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon6',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon7'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon7',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon8'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon8',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_BattleshipPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_BattleshipPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Cruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Cruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon5'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon5',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon6'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon6',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Cruisers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon7'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon7',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Cruisers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon8'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon8',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Cruisers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon9'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon9',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Cruisers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon10'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon10',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon11'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon11',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Cruisers', 'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon12'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon12',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Cruisers', 'Frigates', 'Submarines'},
+                    },
+
+
+
+                    -- Mixed
+                    ['OSB_Child_NavalAttacks_T2SubmarinePlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2SubmarinePlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2SubmarinePlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2SubmarinePlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T2Submarines', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_UtilityPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_UtilityPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_CarrierPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_CarrierPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 4} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers'},
+                    },
+                    ['OSB_Child_NavalAttacks_NukeSubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_NukeSubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+							{'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 2, 3} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'NukeSubmarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon5'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon5',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon6'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon6',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3MixedPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3MixedPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 4, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Carriers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3MixedPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3MixedPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 3, 4, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers', 'Cruisers'},
+                    },
+
+
+
+                    -- Aeon Specific
+                    ['OSB_Child_NavalAttacks_AABoatPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_AABoatPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1AeonPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1AeonPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Frigates', 'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1AeonPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1AeonPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Submarines', 'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1AeonPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1AeonPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Frigates', 'Submarines', 'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_MissileShipPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_MissileShipPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'MissileShips'},
+                    },
+                    ['OSB_Child_NavalAttacks_AAPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_AAPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2AeonPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2AeonPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'Frigates', 'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3AeonPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3AeonPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'MissleShips'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3AeonPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3AeonPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers', 'MissleShips'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3AeonPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3AeonPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 2, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'MissleShips', 'Cruisers'},
+                    },
+
+
+
+                    -- Cybran Specific
+                    ['OSB_Child_NavalAttacks_T2CybranPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2CybranPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 3, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'T2Submarines', 'UtilityBoats'},
+                    },
+
+
+                    -- Seraphim Specific
+                    ['OSB_Child_NavalAttacks_T3SubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T3Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3SeraphimPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SeraphimPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'T3Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3SeraphimPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SeraphimPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers', 'T3Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3SeraphimPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SeraphimPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 4, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T3Submarines', 'Destroyers'},
+                    },
+
+
+
+                    -- UEF Specific
+                    ['OSB_Child_NavalAttacks_TropBoatPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_TropBoatPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'TorpedoBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'TorpedoBoats', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'TorpedoBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'TorpedoBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'TorpedoBoats', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon5'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon5',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'TorpedoBoats', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon6'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon6',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'TorpedoBoats', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon7'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon7',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'TorpedoBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2UEFPlatoon8'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2UEFPlatoon8',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'TorpedoBoats', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_BattleCruiserPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_BattleCruiserPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'BattleCruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3UEFPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3UEFPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'BattleCruisers', 'Battleships'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3UEFPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3UEFPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty', {'default_brain','default_master'} },
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/editor/miscbuildconditions.lua', 'FactionIndex', {'default_brain', 1, 0} },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'BattleCruisers', 'Destroyers'},
+                    },
+
+
+
+                    ['OSB_Master_NavalAttacks'] =  {
+                        PlatoonTemplate = 'OST_BLANK_TEMPLATE',
+                        Priority = 500,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        BuildTimeOut = 240,
+                        PlatoonType = 'Any',
+                        RequiresConstruction = false,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat', {'default_platoon'} },
+                        BuildConditions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock', {'default_brain','default_master'} },
+                            {'/lua/ai/opai/NavalAttacks_editorfunctions.lua', 'NavalAttacksMasterCountDifficulty', {'default_brain','default_master'} },
+                        },
+                        PlatoonBuildCallbacks = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon', {'default_brain','default_platoon'} },
+                        },
+                        PlatoonAddFunctions = {
+                            {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon', {'default_platoon'} },
+                        },
+                        PlatoonData = {
+                            {type = 3, name = 'AMMasterPlatoon',  value = true},
+                            {type = 3, name = 'UsePool', value = false},
+                        },
+                    },
+                },
+            },
+        },
+    },
+}

--- a/hook/lua/AI/aiutilities.lua
+++ b/hook/lua/AI/aiutilities.lua
@@ -263,3 +263,40 @@ function GetNumTransportSlots(unit)
 
     return bones
 end
+
+--------------------
+-- Cheat Utilities
+--------------------
+
+---@param aiBrain AIBrain
+---@param cheatBool boolean
+function SetupCampaignCheat(aiBrain, cheatBool)
+    if cheatBool then
+        aiBrain.CampaignCheatEnabled = true
+
+        local buffDef = Buffs['CheatBuildRate']
+        local buffAffects = buffDef.Affects
+        buffAffects.BuildRate.Mult = tonumber(ScenarioInfo.Options.CampaignBuildMult)
+
+        buffDef = Buffs['CheatIncome']
+        buffAffects = buffDef.Affects
+        buffAffects.EnergyProduction.Mult = tonumber(ScenarioInfo.Options.CampaignCheatMult)
+        buffAffects.MassProduction.Mult = tonumber(ScenarioInfo.Options.CampaignCheatMult)
+
+        local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
+        for _, v in pool:GetPlatoonUnits() do
+            -- Apply build rate and income buffs
+            ApplyCampaignCheatBuffs(v)
+        end
+    end
+end
+
+---@param unit Unit
+function ApplyCampaignCheatBuffs(unit)
+    Buff.ApplyBuff(unit, 'CheatIncome')
+    Buff.ApplyBuff(unit, 'CheatBuildRate')
+	
+	-- Flag the unit as buffed, to avoid duplicate buff applications on maps that manually buff units via map script
+	unit.EcoBuffed = true
+	unit.BuildBuffed = true
+end

--- a/hook/lua/aibrains/campaign-ai.lua
+++ b/hook/lua/aibrains/campaign-ai.lua
@@ -8,15 +8,28 @@ local AIBuildUnits = import("/lua/ai/aibuildunits.lua")
 -- upvalue scope for performance
 local TableGetn = table.getn
 
-local CoopAIBrain = AIBrain
+local CampaignAIBrain = AIBrain
 
 --- A hook of the default FAF campaign AI brain with some modifications.
 --- Added functions that are not included in the basic AI brain type, those are required for some of the platoon functions found in platoon.lua
 ---@class CampaignAIBrain: AIBrain
 ---@field PBM AiPlatoonBuildManager
 ---@field IMAPConfig
-AIBrain = Class(CoopAIBrain) {
+AIBrain = Class(CampaignAIBrain) {
 
+	--- Called after `SetupSession` but before `BeginSession` - no initial units, props or resources exist at this point
+    ---@param self CampaignAIBrain
+    ---@param planName string
+	OnCreateAI = function(self, planName)
+		CampaignAIBrain.OnCreateAI(self, planName)
+		
+		-- 1 -> Disabled; 2 -> Enabled
+		if self.BrainType == 'AI' and ScenarioInfo.Options.CampaignAICheat == 2 then
+			LOG('Campaign AI cheats have been enabled, setting up cheat modifiers for use')
+			AIUtils.SetupCampaignCheat(self, true)
+		end
+	end,
+	
 	-- Main building and forming platoon thread for the Platoon Build Manager
     ---@param self CampaignAIBrain
     PlatoonBuildManagerThread = function(self)

--- a/hook/lua/sim/Unit.lua
+++ b/hook/lua/sim/Unit.lua
@@ -1,0 +1,15 @@
+do
+
+local CampaignUnit = Unit
+
+Unit = Class(CampaignUnit) {
+	---@param self Unit
+    OnCreate = function(self)
+		CampaignUnit.OnCreate(self)
+		
+		if self.Brain.CampaignCheatEnabled then
+			AIUtils.ApplyCampaignCheatBuffs(self)
+		end
+	end,
+}
+end

--- a/lua/AI/LobbyOptions/LobbyOptions.lua
+++ b/lua/AI/LobbyOptions/LobbyOptions.lua
@@ -1,0 +1,42 @@
+AIOpts = {
+    {
+        default = 1,
+        label = "Enable/Disable Campaign AI cheats",
+        help = "Enable, or disable Campaign AI cheats, they are applied to all AI armies, including allied ones.",
+        key = 'CampaignAICheat',
+        values = {
+            {
+                text = "Disabled",
+                help = "Campaign AIs will not receive any cheat modifiers.",
+                key = 1,
+            },
+            {
+                text = "Enabled",
+                help = "Campaign AIs will receive cheat modifiers.",
+                key = 2,
+            },
+        },
+    },
+	{
+        default = 1,
+        label = "Economy Cheat Rates:",
+        help = "Set the Economy cheat multiplier for the Campaign AIs, only relevant if the cheats are enabled. 1.0 rate is no change, in case you want to apply just 1 type of cheat.",
+        key = 'CampaignCheatMult',
+		value_text = "%s",
+        value_help = "Cheat multiplier of %s",
+        values = {
+            '1.0', '1.25', '1.5', '1.75', '2.0', '2.25', '2.5', '2.75', '3.0', '3.25', '3.5', '3.75', '4.0',
+        },
+    },
+	{
+        default = 1,
+        label = "Build Power Cheat Rates:",
+        help = "Set the Build Power cheat multiplier for the Campaign AIs, only relevant if the cheats are enabled. 1.0 rate is no change, in case you want to apply just 1 type of cheat.",
+		key = 'CampaignBuildMult',
+		value_text = "%s",
+        value_help = "Cheat multiplier of %s",
+        values = {
+			'1.0', '1.25', '1.5', '1.75', '2.0', '2.25', '2.5', '2.75', '3.0', '3.25', '3.5', '3.75', '4.0',
+        },
+    },
+}

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -1,6 +1,6 @@
 name = "Coop AI Adjustments"
-uid = "coop_ai_mod_v5"
-version = 5
+uid = "coop_ai_mod_v6"
+version = 6
 copyright = "MIT License"
 description = "Campaign AI fixes, adjustmenst, and QoL changes, still WIP."
 icon = ""


### PR DESCRIPTION
-Added cheat options for the campaign AIs, practically the same way cheats are applied to skirmish AIs.
-Major cleanups in the most commonly used *save.lua* files in *lua/AI/OpAI* folder